### PR TITLE
Updated serving client from storage provider.

### DIFF
--- a/configs/agones-default-values.yaml
+++ b/configs/agones-default-values.yaml
@@ -126,7 +126,7 @@ agones:
     generateTLS: true
   image:
     registry: gcr.io/agones-images
-    tag: 1.17.0
+    tag: 1.28.0
     controller:
       name: agones-controller
       pullPolicy: IfNotPresent

--- a/etherealengine/Chart.yaml
+++ b/etherealengine/Chart.yaml
@@ -7,8 +7,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 5.1.3
+version: 5.2.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 1.3.0
+appVersion: 1.4.0

--- a/etherealengine/templates/client-configmap.yaml
+++ b/etherealengine/templates/client-configmap.yaml
@@ -1,4 +1,4 @@
-{{- if and (.Values.client).enabled (ne (.Values.client).serveFromApi true) -}}
+{{- if and (.Values.client).enabled (ne (.Values.client).serveFromApi true) (ne (((.Values.builder.extraEnv).SERVE_CLIENT_FROM_STORAGE_PROVIDER) | default "false") "true") -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/etherealengine/templates/client-deployment.yaml
+++ b/etherealengine/templates/client-deployment.yaml
@@ -1,4 +1,4 @@
-{{- if and (.Values.client).enabled (ne (.Values.client).serveFromApi true) -}}
+{{- if and (.Values.client).enabled (ne (.Values.client).serveFromApi true) (ne (((.Values.builder.extraEnv).SERVE_CLIENT_FROM_STORAGE_PROVIDER) | default "false") "true") -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/etherealengine/templates/client-ingress.yaml
+++ b/etherealengine/templates/client-ingress.yaml
@@ -1,4 +1,4 @@
-{{- if and (.Values.client).enabled (ne (((.Values.client).ingress).disabled | default false) true) -}}
+{{- if and (.Values.client).enabled (ne (((.Values.client).ingress).disabled | default false) true) (ne (((.Values.builder.extraEnv).SERVE_CLIENT_FROM_STORAGE_PROVIDER) | default "false") "true") -}}
 {{- $clientFullName := include "etherealengine.client.fullname" . -}}
 {{- $apiFullName := include "etherealengine.api.fullname" . -}}
 {{- $svcPort := .Values.client.service.port -}}

--- a/etherealengine/templates/client-service.yaml
+++ b/etherealengine/templates/client-service.yaml
@@ -1,4 +1,4 @@
-{{- if and ((.Values.client).enabled) (ne (.Values.client).serveFromApi true) -}}
+{{- if and ((.Values.client).enabled) (ne (.Values.client).serveFromApi true) (ne (((.Values.builder.extraEnv).SERVE_CLIENT_FROM_STORAGE_PROVIDER) | default "false") "true") -}}
 apiVersion: v1
 kind: Service
 metadata:

--- a/etherealengine/templates/client-serviceaccount.yaml
+++ b/etherealengine/templates/client-serviceaccount.yaml
@@ -1,4 +1,4 @@
-{{- if and ((.Values.client).enabled) (((.Values.client).serviceAccount).create) (ne (.Values.client).serveFromApi true) -}}
+{{- if and ((.Values.client).enabled) (((.Values.client).serviceAccount).create) (ne (.Values.client).serveFromApi true) (ne (((.Values.builder.extraEnv).SERVE_CLIENT_FROM_STORAGE_PROVIDER) | default "false") "true") -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:


### PR DESCRIPTION
Serving the client from the storage provider now serves everything from there. Previously, the root index.html file was coming from the EKS cluster (api pod or client pod), while every other client file was built to and served from the Cloudfront domain. This was inefficient in multiple ways, both in building and storing client files on Docker image and pods just to serve that one file, and because it requires maintaining multiple domains for client files.

Client build will now use an alternate Dockerfile that doesn't do anything besides push the files to S3. build_and_publish_package.sh will not push this image to ECR since it will not be served by Kubernetes.

Updated Agones config to use 1.28.0