### PR TITLE
Removing CACHE_BUCKET_STEM since it is not used anymore

### DIFF
--- a/configs/dev.template.values.yaml
+++ b/configs/dev.template.values.yaml
@@ -380,7 +380,6 @@ taskserver:
 
 builder:
   extraEnv:
-    CACHE_BUCKET_STEM: <S3_CACHE_NAME_STEM>
     NODE_ENV: production
     RELEASE_NAME: <RELEASE_NAME>
     EKS_AWS_ACCESS_KEY: <EKS_USER_AWS_ACCESS_KEY>

--- a/configs/prod.template.values.yaml
+++ b/configs/prod.template.values.yaml
@@ -377,7 +377,6 @@ taskserver:
 
 builder:
   extraEnv:
-    CACHE_BUCKET_STEM: <S3_CACHE_NAME_STEM>
     NODE_ENV: production
     RELEASE_NAME: <RELEASE_NAME>
     EKS_AWS_ACCESS_KEY: <EKS_USER_AWS_ACCESS_KEY>


### PR DESCRIPTION
Caching in ECR means no more need to cache in S3.

References [#7984](https://github.com/EtherealEngine/etherealengine/issues/7984)