### PR TITLE
Update deployment files for local mounting

### DIFF
--- a/configs/local.microk8s.template.values.yaml
+++ b/configs/local.microk8s.template.values.yaml
@@ -29,6 +29,10 @@ client:
     type: NodePort
 domain: etherealengine.org
 clusterType: microk8s
+etherealEngine:
+  # This is the path to your local Ethereal Engine folder that you want to run.
+  # It could be something similar to /home//<OS_USER_NAME>/<ENGINE_FOLDER>
+  localPath: '<EtherealEngine_Local_Folder>'
 sql:
   database: etherealengine
   password: password
@@ -92,7 +96,7 @@ api:
     SMTP_PORT: "465"
     SMTP_SECURE: "true"
     SMTP_USER: <SMTP_USER_ID>
-    STORAGE_PROVIDER: s3
+    STORAGE_PROVIDER: s3 #local
     STORAGE_PROVIDER_EXTERNAL_ENDPOINT: "https://10.0.1.1:9000"
     LOCAL_STORAGE_PROVIDER: "localhost:8642"
     LOCAL_STORAGE_PROVIDER_PORT: "8642"

--- a/etherealengine/templates/api-server-deployment.yaml
+++ b/etherealengine/templates/api-server-deployment.yaml
@@ -130,6 +130,8 @@ spec:
           volumeMounts:
             - mountPath: /app/packages/server/upload
               name: file-server
+            - mountPath: /app/packages
+              name: file-local-mount
           {{- end }}
       {{ if eq .Values.api.extraEnv.STORAGE_PROVIDER "local" }}
       volumes:
@@ -143,6 +145,10 @@ spec:
             path: {{ .Values.api.fileServer.hostUploadFolder }}
             type: DirectoryOrCreate
         {{- end }}
+        - name: file-local-mount
+          hostPath:
+            path: $({{ .Values.etherealEngine.localPath }}/packages)
+            type: Directory
       {{- end }}
       initContainers:
         - name: init-redis

--- a/etherealengine/templates/client-deployment.yaml
+++ b/etherealengine/templates/client-deployment.yaml
@@ -106,7 +106,19 @@ spec:
             initialDelaySeconds: 10
           resources:
             {{- toYaml .Values.client.resources | nindent 12 }}
+          {{ if eq .Values.api.extraEnv.STORAGE_PROVIDER "local" }}
+          volumeMounts:
+            - mountPath: /app/packages
+              name: file-local-mount
+          {{- end }}
       {{- with .Values.client.nodeSelector }}
+      {{ if eq .Values.api.extraEnv.STORAGE_PROVIDER "local" }}
+      volumes:
+        - name: file-local-mount
+          hostPath:
+            path: $({{ .Values.etherealEngine.localPath }}/packages)
+            type: Directory
+      {{- end }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/etherealengine/templates/media-server-deployment.yaml
+++ b/etherealengine/templates/media-server-deployment.yaml
@@ -109,6 +109,18 @@ spec:
             initialDelaySeconds: 10
           resources:
             {{- toYaml .Values.media.resources | nindent 12 }}
+          {{ if eq .Values.api.extraEnv.STORAGE_PROVIDER "local" }}
+          volumeMounts:
+            - mountPath: /app/packages
+              name: file-local-mount
+          {{- end }}
+      {{ if eq .Values.api.extraEnv.STORAGE_PROVIDER "local" }}
+      volumes:
+        - name: file-local-mount
+          hostPath:
+            path: $({{ .Values.etherealEngine.localPath }}/packages)
+            type: Directory
+      {{- end }}
       initContainers:
         - name: init-redis
           image: busybox:1.28

--- a/etherealengine/templates/task-server-deployment.yaml
+++ b/etherealengine/templates/task-server-deployment.yaml
@@ -117,7 +117,19 @@ spec:
             initialDelaySeconds: 10
           resources:
             {{- toYaml .Values.taskserver.resources | nindent 12 }}
+          {{ if eq .Values.api.extraEnv.STORAGE_PROVIDER "local" }}
+          volumeMounts:
+            - mountPath: /app/packages
+              name: file-local-mount
+          {{- end }}
       {{- with .Values.taskserver.nodeSelector }}
+      {{ if eq .Values.api.extraEnv.STORAGE_PROVIDER "local" }}
+      volumes:
+        - name: file-local-mount
+          hostPath:
+            path: $({{ .Values.etherealEngine.localPath }}/packages)
+            type: Directory
+      {{- end }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}


### PR DESCRIPTION
This PR updates the helm files for the deployment of EE to be able to mount the local file system with that of the EE application deployed on Microk8s. This pertains to the following tickets. 

- https://github.com/EtherealEngine/etherealengine-control-center/issues/146#event-10363486690
- https://github.com/EtherealEngine/etherealengine-control-center/issues/147