### PR TITLE
Fixed crashloopbackoff for agones extensions pod & bumped v1.35.0

### DIFF
--- a/configs/agones-default-values.yaml
+++ b/configs/agones-default-values.yaml
@@ -126,9 +126,12 @@ agones:
     generateTLS: true
   image:
     registry: us-docker.pkg.dev/agones-images/release
-    tag: 1.33.0
+    tag: 1.35.0
     controller:
       name: agones-controller
+      pullPolicy: IfNotPresent
+    extensions:
+      name: agones-extensions
       pullPolicy: IfNotPresent
     sdk:
       name: agones-sdk
@@ -143,8 +146,15 @@ agones:
     allocator:
       name: agones-allocator
       pullPolicy: IfNotPresent
-
-
+    extensions:
+      tolerations:
+      - key: "agones.dev/agones-system"
+        operator: "Equal"
+        value: "true"
+        effect: "NoExecute"
+      generateTLS: true
+      disableSecret: false
+      
 gameservers:
   namespaces:
     - default


### PR DESCRIPTION
- Crashloopbackoff issue fixed for agones extension
- Updated agones to version v1.35.0
