### PR TITLE
Disabled agones allocator in config file

### DIFF
--- a/configs/agones-default-values.yaml
+++ b/configs/agones-default-values.yaml
@@ -100,7 +100,7 @@ agones:
       failureThreshold: 3
       timeoutSeconds: 1
   allocator:
-    install: true
+    install: false
     healthCheck:
       initialDelaySeconds: 3
       periodSeconds: 3


### PR DESCRIPTION
The engine does not use the allocator for anything, and it creates a Load Balancer that costs money.