### PR TITLE
Added some options for preserving client IP on requests

### DIFF
--- a/configs/nginx-ingress-aws-values.yml
+++ b/configs/nginx-ingress-aws-values.yml
@@ -22,6 +22,7 @@ controller:
   opentelemetry:
     enabled: false
   service:
+    externalTrafficPolicy: Local
     targetPorts:
       http: http
       https: special # SSL termination at the load balancer
@@ -32,5 +33,5 @@ controller:
       service.beta.kubernetes.io/aws-load-balancer-backend-protocol: "tcp"
       service.beta.kubernetes.io/aws-load-balancer-ssl-ports: "https"
       service.beta.kubernetes.io/aws-load-balancer-type: "nlb"
+      service.beta.kubernetes.io/aws-load-balancer-proxy-protocol: "*"
       service.beta.kubernetes.io/aws-load-balancer-ssl-cert: "<ACM Certificate ARN for SSL>"
-


### PR DESCRIPTION
The IP address on X-Forwarded-For and X-Real-IP was always the IP of one of the nodes, not the requesting client. After some experimentation, determined that for nginx to preserve the requesting client's IP, it was needed to set
service.externalTrafficPolicy to "Local" and to sett the annotation service.beta.kubernetes.io/aws-load-balancer-proxy-protocol to "*" on the nginx Helm deployment.